### PR TITLE
Incremental images

### DIFF
--- a/assets/javascript/reveal.js
+++ b/assets/javascript/reveal.js
@@ -22,8 +22,14 @@
         .removeClass('hide')
         .addClass('show')
         .each(function(index, item) {
+          var $item = $(item)
+          $item.find('img').each(function(_index, img) {
+            var $img = $(img)
+            var src = $img.data('src')
+            $img.attr('src', src)
+          })
           var delay = 10 + index * revealDelay
-          setTimeout(function() { $(item).addClass('reveal') }, delay)
+          setTimeout(function() { $item.addClass('reveal') }, delay)
         })
 
       if (gallery.find('li.hide').size() < 1) {

--- a/assets/javascript/reveal.js
+++ b/assets/javascript/reveal.js
@@ -8,10 +8,6 @@
     var more = $(revealButtonMarkup)
     more.insertAfter(gallery)
 
-    gallery
-      .find('li:not(.js-pick)')
-      .addClass('hide')
-
     more.on('click', function(e) {
       e.preventDefault()
       let items = gallery

--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@ layout: main
   <h1>Bundles</h1>
 
   <ul class="gallery js-reveal">
-    <li class="js-pick">
+    <li>
       <img class="primary" src="images/gallery/bundle-17-open.jpg" alt="">
       <img class="alternate" src="images/gallery/bundle-17.jpg" alt="">
     </li>
-    <li class="js-pick"><img src="images/gallery/bundle-closeup.jpg" alt="bundle closeup"></li>
-    <li class="js-pick"><img src="images/gallery/bundle-18.jpg" alt=""></li>
-    <li class="js-pick"><img src="images/gallery/ff-bundle-6.jpg" alt=""></li>
-    <li class="js-pick"><img src="images/gallery/bundle-24.jpg" alt=""></li>
-    <li class="js-pick"><img src="images/gallery/bundle-11.jpg" alt="bundle of hope"></li>
+    <li><img src="images/gallery/bundle-closeup.jpg" alt="bundle closeup"></li>
+    <li><img src="images/gallery/bundle-18.jpg" alt=""></li>
+    <li><img src="images/gallery/ff-bundle-6.jpg" alt=""></li>
+    <li><img src="images/gallery/bundle-24.jpg" alt=""></li>
+    <li><img src="images/gallery/bundle-11.jpg" alt="bundle of hope"></li>
     <li class="hide"><img src="#" data-src="images/gallery/bundle-20.jpg" alt=""></li>
     <li class="hide"><img src="#" data-src="images/gallery/bundle-21.jpg" alt=""></li>
     <li class="hide"><img src="#" data-src="images/gallery/bundle-22.jpg" alt=""></li>
@@ -98,12 +98,12 @@ layout: main
   <h1>Bottles</h1>
 
   <ul class="gallery js-reveal">
-    <li class="js-pick"><img src="images/gallery/mh-bottle.jpg" alt=""></li>
-    <li class="js-pick">
+    <li><img src="images/gallery/mh-bottle.jpg" alt=""></li>
+    <li>
       <img class="primary" src="images/gallery/ff-bottle-10-top.jpg" alt="">
       <img class="alternate" src="images/gallery/ff-bottle-10-3.jpg" alt="">
     </li>
-    <li class="js-pick"><img src="images/gallery/ff-bottle-2.jpg" alt=""></li>
+    <li><img src="images/gallery/ff-bottle-2.jpg" alt=""></li>
     <li class="hide"><img src="#" data-src="images/gallery/ff-bottle-3.jpg" alt=""></li>
     <li class="hide"><img src="#" data-src="images/gallery/ff-bottle-4.jpg" alt=""></li>
     <li class="hide">

--- a/index.html
+++ b/index.html
@@ -36,61 +36,61 @@ layout: main
     <li class="js-pick"><img src="images/gallery/ff-bundle-6.jpg" alt=""></li>
     <li class="js-pick"><img src="images/gallery/bundle-24.jpg" alt=""></li>
     <li class="js-pick"><img src="images/gallery/bundle-11.jpg" alt="bundle of hope"></li>
-    <li><img src="#" data-src="images/gallery/bundle-20.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/bundle-21.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/bundle-22.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-1.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/bundle-23.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-13.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/bundle-19.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-5.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-2.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-4.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-3.jpg" alt=""></li>
-    <li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-20.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-21.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-22.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-1.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-23.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-13.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-19.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-5.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-2.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-4.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-3.jpg" alt=""></li>
+    <li class="hide">
       <img class="primary" src="#" data-src="images/gallery/ff-bundle-8.jpg" alt="">
       <img class="alternate" src="#" data-src="images/gallery/ff-bundle-8-top.jpg" alt="">
     </li>
-    <li>
+    <li class="hide">
       <img class="primary" src="#" data-src="images/gallery/ff-bundle-7.jpg" alt="">
       <img class="alternate" src="#" data-src="images/gallery/ff-bundle-7-top.jpg" alt="">
     </li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-9.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-10.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/bundle-9-open.jpg" alt="bundle open"></li>
-    <li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-9.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-10.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-9-open.jpg" alt="bundle open"></li>
+    <li class="hide">
       <img class="primary" src="#" data-src="images/gallery/demi-bundle-2-open.jpg" alt="demi bundle of sweetness open">
       <img class="alternate" src="#" data-src="images/gallery/demi-bundle-2-close.jpg" alt="demi bundle alternate">
     </li>
-    <li><img src="#" data-src="images/gallery/bundle-3.jpg" alt="bundle of promise"></li>
-    <li><img src="#" data-src="images/gallery/bundle-8.jpg" alt="bundle of beauty"></li>
-    <li><img src="#" data-src="images/gallery/demi-bundle-1.jpg" alt="demi bundle of beauty"></li>
-    <li><img src="#" data-src="images/gallery/bundle-10.jpg" alt="bundle of beauty"></li>
-    <li><img src="#" data-src="images/gallery/bundle-1.jpg" alt="bundle of joy"></li>
-    <li><img src="#" data-src="images/gallery/bundle-16.jpg" alt=""></li>
-    <li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-3.jpg" alt="bundle of promise"></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-8.jpg" alt="bundle of beauty"></li>
+    <li class="hide"><img src="#" data-src="images/gallery/demi-bundle-1.jpg" alt="demi bundle of beauty"></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-10.jpg" alt="bundle of beauty"></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-1.jpg" alt="bundle of joy"></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-16.jpg" alt=""></li>
+    <li class="hide">
       <img class="primary" src="#" data-src="images/gallery/bundle-9-top.jpg" alt="bundle of peace alternate">
       <img class="alternate" src="#" data-src="images/gallery/bundle-9.jpg" alt="bundle of peace">
     </li>
-    <li><img src="#" data-src="images/gallery/bundle-7.jpg" alt="bundle of peace"></li>
-    <li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-7.jpg" alt="bundle of peace"></li>
+    <li class="hide">
       <img class="primary" src="#" data-src="images/gallery/bundle-12.jpg" alt="bundle of love">
       <img class="alternate" src="#" data-src="images/gallery/bundle-12-open.jpg" alt="bundle of love alternate">
     </li>
-    <li><img src="#" data-src="images/gallery/bundle-15.jpg" alt="bundle of wholeness"></li>
-    <li><img src="#" data-src="images/gallery/bundle-5.jpg" alt="bundle of wholeness"></li>
-    <li><img src="#" data-src="images/gallery/bundle-13.jpg" alt="bundle of love"></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-11.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-14.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-15.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-16.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-17.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-18.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/bundle-14.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-19.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-20.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-21.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bundle-22.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-15.jpg" alt="bundle of wholeness"></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-5.jpg" alt="bundle of wholeness"></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-13.jpg" alt="bundle of love"></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-11.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-14.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-15.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-16.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-17.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-18.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/bundle-14.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-19.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-20.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-21.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bundle-22.jpg" alt=""></li>
   </ul>
 
   <hr class="dashed">
@@ -104,26 +104,26 @@ layout: main
       <img class="alternate" src="images/gallery/ff-bottle-10-3.jpg" alt="">
     </li>
     <li class="js-pick"><img src="images/gallery/ff-bottle-2.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bottle-3.jpg" alt=""></li>
-    <li><img src="#" data-src="images/gallery/ff-bottle-4.jpg" alt=""></li>
-    <li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bottle-3.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bottle-4.jpg" alt=""></li>
+    <li class="hide">
       <img class="alternate" src="#" data-src="images/gallery/ff-bottle-5.jpg" alt="">
       <img class="primary" src="#" data-src="images/gallery/ff-bottle-5-top.jpg" alt="">
     </li>
-    <li><img src="#" data-src="images/gallery/ff-bottle-6.jpg" alt=""></li>
-    <li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bottle-6.jpg" alt=""></li>
+    <li class="hide">
       <img class="primary" src="#" data-src="images/gallery/ff-bottle-7-top.jpg" alt="">
       <img class="alternate" src="#" data-src="images/gallery/ff-bottle-7.jpg" alt="">
     </li>
-    <li>
+    <li class="hide">
       <img class="primary" src="#" data-src="images/gallery/ff-bottle-8.jpg" alt="">
       <img class="alternate" src="#" data-src="images/gallery/ff-bottle-8-top.jpg" alt="">
     </li>
-    <li>
+    <li class="hide">
       <img class="primary" src="#" data-src="images/gallery/ff-bottle-9-1.jpg" alt="">
       <img class="alternate" src="#" data-src="images/gallery/ff-bottle-9-top.jpg" alt="">
     </li>
-    <li><img src="#" data-src="images/gallery/ff-bottle-1.jpg" alt=""></li>
+    <li class="hide"><img src="#" data-src="images/gallery/ff-bottle-1.jpg" alt=""></li>
   </ul>
 
   <h3>—</h3>

--- a/index.html
+++ b/index.html
@@ -36,61 +36,61 @@ layout: main
     <li class="js-pick"><img src="images/gallery/ff-bundle-6.jpg" alt=""></li>
     <li class="js-pick"><img src="images/gallery/bundle-24.jpg" alt=""></li>
     <li class="js-pick"><img src="images/gallery/bundle-11.jpg" alt="bundle of hope"></li>
-    <li><img src="images/gallery/bundle-20.jpg" alt=""></li>
-    <li><img src="images/gallery/bundle-21.jpg" alt=""></li>
-    <li><img src="images/gallery/bundle-22.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-1.jpg" alt=""></li>
-    <li><img src="images/gallery/bundle-23.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-13.jpg" alt=""></li>
-    <li><img src="images/gallery/bundle-19.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-5.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-2.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-4.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-3.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/bundle-20.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/bundle-21.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/bundle-22.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-1.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/bundle-23.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-13.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/bundle-19.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-5.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-2.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-4.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-3.jpg" alt=""></li>
     <li>
-      <img class="primary" src="images/gallery/ff-bundle-8.jpg" alt="">
-      <img class="alternate" src="images/gallery/ff-bundle-8-top.jpg" alt="">
+      <img class="primary" src="#" data-src="images/gallery/ff-bundle-8.jpg" alt="">
+      <img class="alternate" src="#" data-src="images/gallery/ff-bundle-8-top.jpg" alt="">
     </li>
     <li>
-      <img class="primary" src="images/gallery/ff-bundle-7.jpg" alt="">
-      <img class="alternate" src="images/gallery/ff-bundle-7-top.jpg" alt="">
+      <img class="primary" src="#" data-src="images/gallery/ff-bundle-7.jpg" alt="">
+      <img class="alternate" src="#" data-src="images/gallery/ff-bundle-7-top.jpg" alt="">
     </li>
-    <li><img src="images/gallery/ff-bundle-9.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-10.jpg" alt=""></li>
-    <li><img src="images/gallery/bundle-9-open.jpg" alt="bundle open"></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-9.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-10.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/bundle-9-open.jpg" alt="bundle open"></li>
     <li>
-      <img class="primary" src="images/gallery/demi-bundle-2-open.jpg" alt="demi bundle of sweetness open">
-      <img class="alternate" src="images/gallery/demi-bundle-2-close.jpg" alt="demi bundle alternate">
+      <img class="primary" src="#" data-src="images/gallery/demi-bundle-2-open.jpg" alt="demi bundle of sweetness open">
+      <img class="alternate" src="#" data-src="images/gallery/demi-bundle-2-close.jpg" alt="demi bundle alternate">
     </li>
-    <li><img src="images/gallery/bundle-3.jpg" alt="bundle of promise"></li>
-    <li><img src="images/gallery/bundle-8.jpg" alt="bundle of beauty"></li>
-    <li><img src="images/gallery/demi-bundle-1.jpg" alt="demi bundle of beauty"></li>
-    <li><img src="images/gallery/bundle-10.jpg" alt="bundle of beauty"></li>
-    <li><img src="images/gallery/bundle-1.jpg" alt="bundle of joy"></li>
-    <li><img src="images/gallery/bundle-16.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/bundle-3.jpg" alt="bundle of promise"></li>
+    <li><img src="#" data-src="images/gallery/bundle-8.jpg" alt="bundle of beauty"></li>
+    <li><img src="#" data-src="images/gallery/demi-bundle-1.jpg" alt="demi bundle of beauty"></li>
+    <li><img src="#" data-src="images/gallery/bundle-10.jpg" alt="bundle of beauty"></li>
+    <li><img src="#" data-src="images/gallery/bundle-1.jpg" alt="bundle of joy"></li>
+    <li><img src="#" data-src="images/gallery/bundle-16.jpg" alt=""></li>
     <li>
-      <img class="primary" src="images/gallery/bundle-9-top.jpg" alt="bundle of peace alternate">
-      <img class="alternate" src="images/gallery/bundle-9.jpg" alt="bundle of peace">
+      <img class="primary" src="#" data-src="images/gallery/bundle-9-top.jpg" alt="bundle of peace alternate">
+      <img class="alternate" src="#" data-src="images/gallery/bundle-9.jpg" alt="bundle of peace">
     </li>
-    <li><img src="images/gallery/bundle-7.jpg" alt="bundle of peace"></li>
+    <li><img src="#" data-src="images/gallery/bundle-7.jpg" alt="bundle of peace"></li>
     <li>
-      <img class="primary" src="images/gallery/bundle-12.jpg" alt="bundle of love">
-      <img class="alternate" src="images/gallery/bundle-12-open.jpg" alt="bundle of love alternate">
+      <img class="primary" src="#" data-src="images/gallery/bundle-12.jpg" alt="bundle of love">
+      <img class="alternate" src="#" data-src="images/gallery/bundle-12-open.jpg" alt="bundle of love alternate">
     </li>
-    <li><img src="images/gallery/bundle-15.jpg" alt="bundle of wholeness"></li>
-    <li><img src="images/gallery/bundle-5.jpg" alt="bundle of wholeness"></li>
-    <li><img src="images/gallery/bundle-13.jpg" alt="bundle of love"></li>
-    <li><img src="images/gallery/ff-bundle-11.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-14.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-15.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-16.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-17.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-18.jpg" alt=""></li>
-    <li><img src="images/gallery/bundle-14.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-19.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-20.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-21.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bundle-22.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/bundle-15.jpg" alt="bundle of wholeness"></li>
+    <li><img src="#" data-src="images/gallery/bundle-5.jpg" alt="bundle of wholeness"></li>
+    <li><img src="#" data-src="images/gallery/bundle-13.jpg" alt="bundle of love"></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-11.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-14.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-15.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-16.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-17.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-18.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/bundle-14.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-19.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-20.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-21.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bundle-22.jpg" alt=""></li>
   </ul>
 
   <hr class="dashed">
@@ -104,26 +104,26 @@ layout: main
       <img class="alternate" src="images/gallery/ff-bottle-10-3.jpg" alt="">
     </li>
     <li class="js-pick"><img src="images/gallery/ff-bottle-2.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bottle-3.jpg" alt=""></li>
-    <li><img src="images/gallery/ff-bottle-4.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bottle-3.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bottle-4.jpg" alt=""></li>
     <li>
-      <img class="alternate" src="images/gallery/ff-bottle-5.jpg" alt="">
-      <img class="primary" src="images/gallery/ff-bottle-5-top.jpg" alt="">
+      <img class="alternate" src="#" data-src="images/gallery/ff-bottle-5.jpg" alt="">
+      <img class="primary" src="#" data-src="images/gallery/ff-bottle-5-top.jpg" alt="">
     </li>
-    <li><img src="images/gallery/ff-bottle-6.jpg" alt=""></li>
+    <li><img src="#" data-src="images/gallery/ff-bottle-6.jpg" alt=""></li>
     <li>
-      <img class="alternate" src="images/gallery/ff-bottle-7.jpg" alt="">
-      <img class="primary" src="images/gallery/ff-bottle-7-top.jpg" alt="">
-    </li>
-    <li>
-      <img class="primary" src="images/gallery/ff-bottle-8.jpg" alt="">
-      <img class="alternate" src="images/gallery/ff-bottle-8-top.jpg" alt="">
+      <img class="primary" src="#" data-src="images/gallery/ff-bottle-7-top.jpg" alt="">
+      <img class="alternate" src="#" data-src="images/gallery/ff-bottle-7.jpg" alt="">
     </li>
     <li>
-      <img class="primary" src="images/gallery/ff-bottle-9-1.jpg" alt="">
-      <img class="alternate" src="images/gallery/ff-bottle-9-top.jpg" alt="">
+      <img class="primary" src="#" data-src="images/gallery/ff-bottle-8.jpg" alt="">
+      <img class="alternate" src="#" data-src="images/gallery/ff-bottle-8-top.jpg" alt="">
     </li>
-    <li><img src="images/gallery/ff-bottle-1.jpg" alt=""></li>
+    <li>
+      <img class="primary" src="#" data-src="images/gallery/ff-bottle-9-1.jpg" alt="">
+      <img class="alternate" src="#" data-src="images/gallery/ff-bottle-9-top.jpg" alt="">
+    </li>
+    <li><img src="#" data-src="images/gallery/ff-bottle-1.jpg" alt=""></li>
   </ul>
 
   <h3>—</h3>


### PR DESCRIPTION
The current implementation produces a very heavy initial page load (~20MB). By hiding hidden images in the gallery initially, we can get this down to somewhere around ~6MB.