### PR TITLE
Better text wrapping for alerts by styling block-level element

### DIFF
--- a/_sass/components/_alerts.scss
+++ b/_sass/components/_alerts.scss
@@ -1,10 +1,12 @@
 .alert {
-  padding: 0.5em 1em;
+  display: inline-block;
+  padding: 0.25em 1em;
+  margin-bottom: 0.5em;
   border-radius: _size(border-radius);
+  font-size: 1.25em;
 
   &.info {
     background-color: #2ac2ac;//#b7e3e8;
     color: white;
-    font-weight: bold;
   }
 }

--- a/dance-recitals.html
+++ b/dance-recitals.html
@@ -21,7 +21,7 @@ title: Dance Recitals
     Bundles are fresh cut flowers and will be pre-wrapped with flower food.
   </p>
 
-  <h2><span class="alert info">— We are not your typical florist —</span></h2>
+  <div class="alert info">We are not your typical florist</div>
   <p>
     Our bundles will be filled with beautiful stems of what we have on hand.
     Style, color, and arrangement will vary.
@@ -60,11 +60,9 @@ title: Dance Recitals
   </p>
 
   <h1>Select your bundle to get started:</h1>
-  <h3>
-    <span class="alert info">
-      Please include your studio name in the notes with your purchase
-    </span>
-  </h3>
+  <div class="alert info">
+    Please include your studio name in the notes with your purchase
+  </div>
 
   <ul class="gallery">
     <li>


### PR DESCRIPTION
before:
![Screen Shot 2019-05-17 at 3 23 45 PM](https://user-images.githubusercontent.com/79619/57954662-2d8cdd00-78b9-11e9-9dc6-6f1f280df15f.png)
![Screen Shot 2019-05-17 at 3 23 48 PM](https://user-images.githubusercontent.com/79619/57954663-2e257380-78b9-11e9-8c38-359a15b2ce4f.png)

after:
![Screen Shot 2019-05-17 at 3 32 57 PM](https://user-images.githubusercontent.com/79619/57954664-2e257380-78b9-11e9-94bb-67c67d39e412.png)
![Screen Shot 2019-05-17 at 3 33 05 PM](https://user-images.githubusercontent.com/79619/57954665-2e257380-78b9-11e9-9c2c-eeeebe70726f.png)
